### PR TITLE
docs: fix simple typo, othogonal -> orthogonal

### DIFF
--- a/Experiment/SimpleVulkanApp/src/native/linmath.h
+++ b/Experiment/SimpleVulkanApp/src/native/linmath.h
@@ -461,7 +461,7 @@ static inline void mat4x4_from_quat(mat4x4 M, quat q) {
 }
 
 static inline void mat4x4o_mul_quat(mat4x4 R, mat4x4 M, quat q) {
-    /*  XXX: The way this is written only works for othogonal matrices. */
+    /*  XXX: The way this is written only works for orthogonal matrices. */
     /* TODO: Take care of non-orthogonal case. */
     quat_mul_vec3(R[0], q, M[0]);
     quat_mul_vec3(R[1], q, M[1]);


### PR DESCRIPTION
There is a small typo in Experiment/SimpleVulkanApp/src/native/linmath.h.

Should read `orthogonal` rather than `othogonal`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md